### PR TITLE
Enable PDF export and refine markout outputs

### DIFF
--- a/newweeps/calculate.js
+++ b/newweeps/calculate.js
@@ -121,13 +121,14 @@ function calculate(e, system) {
       let label;
       if (system === 'T14000') {
         label = markPoints.length === 1 ? 'Centerline' : idx === 0 ? 'Q1' : 'Q3';
+        results.push(`• ${label} at ${roundToSixteenths(local)} → Part ${seg.part} - ${roundToSixteenths(seg.local)}`);
       } else {
         if (markPoints.length === 1) label = 'Centerline';
         else if (markPoints.length === 2) label = idx === 0 ? '2" from start' : '2" from end';
         else if (markPoints.length === 3) label = ['2" from start', 'Centerline', '2" from end'][idx];
         else label = ['2" from start', '8" from start', '8" from end', '2" from end'][idx];
+        results.push(`• ${label} at ${roundToSixteenths(pt)} → Part ${seg.part} @ ${roundToSixteenths(seg.local)}`);
       }
-      results.push(`• ${label} at ${roundToSixteenths(pt)} → Part ${seg.part} @ ${roundToSixteenths(seg.local)}`);
       pointsByPart[seg.part] = pointsByPart[seg.part] || [];
       pointsByPart[seg.part].push(seg.local);
     });
@@ -140,12 +141,16 @@ function calculate(e, system) {
     : '--- Summary of Points by Part ---');
   Object.keys(pointsByPart).sort((a, b) => a - b).forEach(part => {
     const sorted = pointsByPart[part].sort((a, b) => a - b).map(roundToSixteenths);
-    results.push(`Part ${part}: ${sorted.join(' | ')}`);
+    const seg = spliceSegments.find(s => s.part === parseInt(part));
+    const len = roundToSixteenths(seg.end - seg.start);
+    results.push(`Part ${part} (Length: ${len}): ${sorted.join(' | ')}`);
   });
 
   const resDiv = document.getElementById(`results${system}`);
   resDiv.textContent = `Markout Results:\n\n${results.join('\n')}`;
   resDiv.classList.remove('hidden');
+  const dlBtn = document.getElementById(`download${system}`);
+  if (dlBtn) dlBtn.classList.remove('hidden');
 }
 
 // Wrapper functions for existing references

--- a/newweeps/index.php
+++ b/newweeps/index.php
@@ -32,11 +32,11 @@
       <input type="text" id="trackOffsetT14000" value="0" placeholder="e.g. 3/4" />
 
       <div class="checkbox">
-        <input type="checkbox" id="doorLeftT14000" checked />
+        <input type="checkbox" id="doorLeftT14000" />
         <label for="doorLeftT14000">Door on Left</label>
       </div>
       <div class="checkbox">
-        <input type="checkbox" id="doorRightT14000" checked />
+        <input type="checkbox" id="doorRightT14000" />
         <label for="doorRightT14000">Door on Right</label>
       </div>
 
@@ -65,7 +65,7 @@
     </form>
 
     <div id="resultsT14000" class="result hidden"></div>
-    <button id="downloadT14000">Download Results</button>
+    <button id="downloadT14000" class="hidden">Download Results</button>
   </div>
 
   <!-- T24650 Tab -->
@@ -84,11 +84,11 @@
       <input type="text" id="trackOffsetT24650" value="0" placeholder="e.g. 3/4" />
 
       <div class="checkbox">
-        <input type="checkbox" id="doorLeftT24650" checked />
+        <input type="checkbox" id="doorLeftT24650" />
         <label for="doorLeftT24650">Door on Left</label>
       </div>
       <div class="checkbox">
-        <input type="checkbox" id="doorRightT24650" checked />
+        <input type="checkbox" id="doorRightT24650" />
         <label for="doorRightT24650">Door on Right</label>
       </div>
 
@@ -124,6 +124,8 @@
 
 
   <!-- Script Modules -->
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
   <script src="utils.js"></script>
   <script src="tabs.js"></script>
   <script src="form.js"></script>

--- a/newweeps/main.js
+++ b/newweeps/main.js
@@ -3,6 +3,8 @@
     const container = document.getElementById(`manualSpliceContainer${system}`);
     container.classList.toggle('hidden', !e.target.checked);
   });
+  const dlBtn = document.getElementById(`download${system}`);
+  if (dlBtn) dlBtn.addEventListener('click', () => downloadPDF(system));
 });
 
 // Entry point: run this after DOM is fully loaded

--- a/newweeps/utils.js
+++ b/newweeps/utils.js
@@ -52,6 +52,31 @@ function parseFractionalInput(input) {
     URL.revokeObjectURL(url);
   }
 
+  // Generate a PDF containing the written results and visual markout
+  async function downloadPDF(system) {
+    const { jsPDF } = window.jspdf;
+    const doc = new jsPDF();
+
+    // Add textual results
+    const resDiv = document.getElementById(`results${system}`);
+    const text = resDiv ? resDiv.textContent : '';
+    const lines = doc.splitTextToSize(text, 180);
+    doc.text(lines, 10, 10);
+
+    // Add visual on a new page if available
+    const visual = document.getElementById('markpointVisualizer');
+    if (visual && visual.childElementCount > 0) {
+      const canvas = await html2canvas(visual);
+      const imgData = canvas.toDataURL('image/png');
+      doc.addPage();
+      const pageWidth = doc.internal.pageSize.getWidth() - 20;
+      const pageHeight = canvas.height * pageWidth / canvas.width;
+      doc.addImage(imgData, 'PNG', 10, 10, pageWidth, pageHeight);
+    }
+
+    doc.save(`${system}_markout.pdf`);
+  }
+
 function getAutoSpliceSegmentsBayMidpointsOnly(
   bayWidths,
   spacing,


### PR DESCRIPTION
## Summary
- Add PDF export for both T14000 and T24650 including results text and visual markout
- Default door-left/right checkboxes to unchecked and expose download buttons post-calculation
- Improve markout output formatting and part length summary

## Testing
- `node --check newweeps/utils.js`
- `node --check newweeps/calculate.js`
- `node --check newweeps/main.js`
- `php -l newweeps/index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b3a27a327c83299e78c7bfbc4e732f