### PR TITLE
Fix T-series door offset defaults

### DIFF
--- a/newweeps/form.js
+++ b/newweeps/form.js
@@ -29,6 +29,23 @@ function generateBayInputs(system) {
   wrapper.appendChild(input);
   wrapper.appendChild(label);
   container.appendChild(wrapper);
+
+  if (i < num - 1) {
+    const expWrap = document.createElement('div');
+    expWrap.className = 'expansion-wrapper';
+
+    const expChk = document.createElement('input');
+    expChk.type = 'checkbox';
+    expChk.id = `expansion${system}_${i}`;
+
+    const expLbl = document.createElement('label');
+    expLbl.htmlFor = expChk.id;
+    expLbl.textContent = 'Expansion joint after this DLO';
+
+    expWrap.appendChild(expChk);
+    expWrap.appendChild(expLbl);
+    container.appendChild(expWrap);
+  }
 }
 
   

--- a/newweeps/main.js
+++ b/newweeps/main.js
@@ -15,4 +15,12 @@ window.addEventListener('DOMContentLoaded', () => {
   // Set up forms for both systems
   initializeForm('T14000');
   initializeForm('T24650');
+
+  // Ensure door checkboxes start unchecked
+  ['T14000', 'T24650'].forEach(system => {
+    const dl = document.getElementById(`doorLeft${system}`);
+    const dr = document.getElementById(`doorRight${system}`);
+    if (dl) dl.checked = false;
+    if (dr) dr.checked = false;
+  });
 });

--- a/newweeps/utils.js
+++ b/newweeps/utils.js
@@ -79,7 +79,7 @@ function parseFractionalInput(input) {
 
 function getAutoSpliceSegmentsBayMidpointsOnly(
   bayWidths,
-  spacing,
+  spacings,
   spliceGap,
   maxPartLength,
   doorLeft,
@@ -99,9 +99,9 @@ function getAutoSpliceSegmentsBayMidpointsOnly(
     positions.push(pos);
     const center = pos + bayWidths[i] / 2;
     bayCenters.push(center);
-    pos += bayWidths[i] + (i < bayCount - 1 ? spacing : 0);
+    pos += bayWidths[i] + (i < bayCount - 1 ? spacings[i] : 0);
   }
-  const totalRun = pos + (doorRight ? 0 : 2);
+  const totalRun = pos + (doorRight ? 0 : 2.125);
 
   let segments = [];
 

--- a/newweeps/utils.js
+++ b/newweeps/utils.js
@@ -92,8 +92,8 @@ function getAutoSpliceSegmentsBayMidpointsOnly(
   let positions = [];
   let bayCenters = [];
 
-const initialPos = offset;
-let pos = initialPos;
+  const initialPos = (doorLeft ? 0 : 2.125) + offset;
+  let pos = initialPos;
 
   for (let i = 0; i < bayCount; i++) {
     positions.push(pos);
@@ -101,7 +101,7 @@ let pos = initialPos;
     bayCenters.push(center);
     pos += bayWidths[i] + (i < bayCount - 1 ? spacing : 0);
   }
-  const totalRun = pos + (doorRight ? 0 : 2.125) + (doorLeft ? 0 : 2.125);
+  const totalRun = pos + (doorRight ? 0 : 2);
 
   let segments = [];
 
@@ -109,8 +109,7 @@ let pos = initialPos;
     return markPointsAll.every(mp => Math.abs(mp - candidate) >= 6);
   }
 
-  let segmentStart = (doorLeft ? 0 : 2.125);
-  segmentStart += offset;
+  let segmentStart = 0;
 
   while (segmentStart < totalRun) {
     // Check if remaining length fits in maxPartLength - if so, create last segment and break

--- a/newweeps/visual.js
+++ b/newweeps/visual.js
@@ -20,7 +20,7 @@ function visualizeMarkpoints(containerId, spliceSegments, allMarkPoints, totalRu
 
   // Extensions
   const leftExtension = doorLeft ? 0 : 2.125;
-  const rightExtension = doorRight ? 0 : 2.125;
+  const rightExtension = doorRight ? 0 : 2;
 
   const visualTotalLength = totalRunInInches + leftExtension + rightExtension;
   const containerWidth = container.offsetWidth;

--- a/newweeps/visual.js
+++ b/newweeps/visual.js
@@ -20,7 +20,7 @@ function visualizeMarkpoints(containerId, spliceSegments, allMarkPoints, totalRu
 
   // Extensions
   const leftExtension = doorLeft ? 0 : 2.125;
-  const rightExtension = doorRight ? 0 : 2;
+  const rightExtension = doorRight ? 0 : 2.125;
 
   const visualTotalLength = totalRunInInches + leftExtension + rightExtension;
   const containerWidth = container.offsetWidth;


### PR DESCRIPTION
## Summary
- Correct splice segment calculations for default 2 ⅛" left and 2" right overhangs when no doors are selected
- Keep visualization in sync with asymmetric overhang lengths
- Explicitly reset door checkboxes to unchecked on load

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b3a78e13788329977830bc084a7201