### PR TITLE
Add dark mode and refine visualization scaling

### DIFF
--- a/caps.php
+++ b/caps.php
@@ -1,15 +1,29 @@
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Cap Splice Calculator</title>
+  <link rel="stylesheet" href="css/style.css" />
   <style>
+    :root {
+      --button-bg: #2563eb;
+      --button-hover-bg: #1d4ed8;
+      --button-text: #fff;
+      --border: #ccc;
+      --column-bg: #f0f0f0;
+    }
+    [data-theme="dark"] {
+      --border: #444;
+      --column-bg: #2a2a2a;
+    }
     body {
       font-family: sans-serif;
       padding: 2rem;
-      background: #f9fafb;
+      background: var(--bg);
+      color: var(--text);
+      display: block;
     }
     textarea {
       width: 100%;
@@ -17,25 +31,28 @@
       margin-bottom: 1rem;
       font-size: 1rem;
       padding: 0.5rem;
+      background: var(--card-bg);
+      color: var(--text);
+      border: 1px solid var(--border);
     }
     button {
       padding: 0.75rem 1.5rem;
-      background: #2563eb;
-      color: white;
+      background: var(--button-bg);
+      color: var(--button-text);
       border: none;
       border-radius: 0.375rem;
       cursor: pointer;
       margin-right: 1rem;
     }
     button:hover {
-      background: #1d4ed8;
+      background: var(--button-hover-bg);
     }
     .results {
       margin-top: 2rem;
-      background: white;
+      background: var(--card-bg);
       padding: 1rem;
       border-radius: 0.5rem;
-      box-shadow: 0 0 10px rgba(0,0,0,0.1);
+      box-shadow: 0 0 10px var(--shadow);
     }
     .result-group {
       margin-bottom: 2rem;
@@ -49,7 +66,7 @@
       padding-left: 1.5rem;
     }
     .column {
-      background: #f0f0f0;
+      background: var(--column-bg);
       padding: 0.75rem;
       border-radius: 0.375rem;
     }
@@ -87,7 +104,7 @@
 
   <div id="graphic"></div>
   <div class="results" id="results"></div>
-  
+
 
   <script>
     const MULLION_WIDTH = 2.5;
@@ -311,5 +328,14 @@ document.getElementById("graphic").innerHTML += svg;
       document.body.removeChild(link);
     }
   </script>
+
+  <div class="theme-toggle">
+    <label class="switch">
+      <input type="checkbox" id="theme-toggle">
+      <span class="slider round"></span>
+    </label>
+  </div>
+
+  <script src="js/theme-toggle.js"></script>
 </body>
 </html>

--- a/newweeps/index.php
+++ b/newweeps/index.php
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -123,6 +123,14 @@
 </div>
 
 
+  <!-- Theme Toggle Switch -->
+  <div class="theme-toggle">
+    <label class="switch">
+      <input type="checkbox" id="theme-toggle">
+      <span class="slider round"></span>
+    </label>
+  </div>
+
   <!-- Script Modules -->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html2canvas/1.4.1/html2canvas.min.js"></script>
@@ -132,5 +140,6 @@
   <script src="calculate.js"></script>
   <script src="main.js"></script>
   <script src="visual.js"></script>
+  <script src="../js/theme-toggle.js"></script>
 </body>
 </html>

--- a/newweeps/styles.css
+++ b/newweeps/styles.css
@@ -1,7 +1,46 @@
+/* === Theme Variables === */
+:root {
+  --bg: #f9f9f9;
+  --text: #000;
+  --card-bg: #fff;
+  --border: #ccc;
+  --button-bg: #007aff;
+  --button-text: #fff;
+  --button-hover-bg: #005ecb;
+  --tab-bg: #eee;
+  --tab-active-bg: #007aff;
+  --tab-active-text: #fff;
+  --visual-bar-bg: #f1f1f1;
+  --visual-bar-border: #ccc;
+  --visual-track-bg: #eee;
+  --visual-track-border: #aaa;
+  --markpoint-color: red;
+}
+
+[data-theme="dark"] {
+  --bg: #121212;
+  --text: #fff;
+  --card-bg: #1e1e1e;
+  --border: #555;
+  --button-bg: #005ecb;
+  --button-text: #fff;
+  --button-hover-bg: #004799;
+  --tab-bg: #333;
+  --tab-active-bg: #007aff;
+  --tab-active-text: #fff;
+  --visual-bar-bg: #1f1f1f;
+  --visual-bar-border: #555;
+  --visual-track-bg: #333;
+  --visual-track-border: #555;
+  --markpoint-color: #ff5252;
+}
+
 body {
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen;
   padding: 20px;
-  background: #f9f9f9;
+  background: var(--bg);
+  color: var(--text);
+  transition: background 0.3s, color 0.3s;
 }
 
 h2 {
@@ -21,6 +60,9 @@ input[type="number"] {
   width: 100%;
   padding: 10px;
   box-sizing: border-box;
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
 }
 
 .checkbox {
@@ -35,7 +77,7 @@ input[type="number"] {
 
 #manualSpliceContainer {
   margin-top: 15px;
-  border-left: 3px solid #ccc;
+  border-left: 3px solid var(--border);
   padding-left: 10px;
 }
 
@@ -60,8 +102,8 @@ input[type="number"] {
 }
 
 button {
-  background: #007aff;
-  color: white;
+  background: var(--button-bg);
+  color: var(--button-text);
   border: none;
   border-radius: 6px;
   padding: 10px;
@@ -71,12 +113,13 @@ button {
 }
 
 button:hover {
-  background: #005ecb;
+  background: var(--button-hover-bg);
 }
 
 /* Results Output */
 .result {
-  background: #fff;
+  background: var(--card-bg);
+  color: var(--text);
   padding: 15px;
   border-radius: 6px;
   margin-top: 20px;
@@ -102,8 +145,8 @@ button:hover {
   max-width: 150px;
   margin: 0 5px;
   padding: 10px;
-  background: #eee;
-  border: 1px solid #ccc;
+  background: var(--tab-bg);
+  border: 1px solid var(--border);
   border-bottom: none;
   cursor: pointer;
   font-weight: bold;
@@ -111,16 +154,16 @@ button:hover {
 }
 
 .tab-buttons button.active {
-  background: #007aff;
-  color: white;
-  border-color: #005ecb;
+  background: var(--tab-active-bg);
+  color: var(--tab-active-text);
+  border-color: var(--tab-active-bg);
 }
 
 .tab-content {
-  border: 1px solid #ccc;
+  border: 1px solid var(--border);
   padding: 15px;
   border-radius: 0 6px 6px 6px;
-  background: white;
+  background: var(--card-bg);
 }
 
 /* Download Button Section */
@@ -141,8 +184,8 @@ button:hover {
 
 .visual-bar {
   position: relative;
-  background: #f1f1f1;
-  border: 1px solid #ccc;
+  background: var(--visual-bar-bg);
+  border: 1px solid var(--visual-bar-border);
   overflow-x: hidden;
   border-radius: 6px;
 }
@@ -162,8 +205,8 @@ button:hover {
 .visual-track {
   position: relative;
   height: 40px;
-  background-color: #eee;
-  border: 1px solid #aaa;
+  background-color: var(--visual-track-bg);
+  border: 1px solid var(--visual-track-border);
   margin: 1em;
   display: flex;
   justify-content: center;
@@ -175,7 +218,7 @@ button:hover {
   position: absolute;
   width: 2px;
   height: 20px;
-  background-color: red;
+  background-color: var(--markpoint-color);
   bottom: 0;
   transform: translateX(-50%);
 }
@@ -184,7 +227,7 @@ button:hover {
   position: absolute;
   top: 22px;
   font-size: 12px;
-  color: #222;
+  color: var(--text);
   white-space: nowrap;
   pointer-events: none;
   transform: translateX(-50%);
@@ -219,4 +262,61 @@ flex-direction: column;
   display: flex;
   flex-direction: column;
   align-items: center;
+}
+
+/* === Theme Toggle Button (Bottom Left) === */
+.theme-toggle {
+  position: fixed;
+  bottom: 1rem;
+  left: 1rem;
+}
+
+/* === Slider Switch Style === */
+.switch {
+  position: relative;
+  display: inline-block;
+  width: 44px;
+  height: 24px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  background-color: #888;
+  border-radius: 24px;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  transition: 0.4s;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 3px;
+  bottom: 3px;
+  background-color: white;
+  border-radius: 50%;
+  transition: 0.4s;
+}
+
+input:checked + .slider {
+  background-color: #4caf50;
+}
+
+input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+.slider.round {
+  border-radius: 24px;
 }


### PR DESCRIPTION
## Summary
- Enable dark mode toggle across calculators with shared theme variables
- Rework markpoint visualization to scale by total run and handle empty data

## Testing
- `php -l index.php caps.php newweeps/index.php`
- `node --check newweeps/visual.js`
- `node --check js/theme-toggle.js`


------
https://chatgpt.com/codex/tasks/task_e_68b3be2139b48329b16d96aac8e2ba61