### PR TITLE
Refactor markout results into modal with SVG visualization

### DIFF
--- a/newweeps/calculate.js
+++ b/newweeps/calculate.js
@@ -149,9 +149,12 @@ function calculate(e, system) {
     results.push(`Part ${part} (Length: ${len}): ${sorted.join(' | ')}`);
   });
 
-  const resDiv = document.getElementById(`results${system}`);
-  resDiv.textContent = `Markout Results:\n\n${results.join('\n')}`;
-  resDiv.classList.remove('hidden');
+  const resDiv = document.getElementById('results');
+  if (resDiv) {
+    resDiv.textContent = `Markout Results:\n\n${results.join('\n')}`;
+  }
+  const modal = document.getElementById('resultsModal');
+  if (modal) modal.classList.remove('hidden');
   const dlBtn = document.getElementById(`download${system}`);
   if (dlBtn) dlBtn.classList.remove('hidden');
 }

--- a/newweeps/form.js
+++ b/newweeps/form.js
@@ -52,7 +52,8 @@ function generateBayInputs(system) {
     numBaysInput.style.display = 'none';
     numBaysInput.nextElementSibling.style.display = 'none'; // hide "Next" button
     form.classList.remove('hidden');
-    document.getElementById(`results${system}`).classList.add('hidden');
+    const modal = document.getElementById('resultsModal');
+    if (modal) modal.classList.add('hidden');
   }
   
   // Add a new manual splice input row
@@ -114,7 +115,8 @@ function resetForm(system) {
   // Clear form fields and hide sections
   document.getElementById(`bayInputs${system}`).innerHTML = '';
   document.getElementById(`mainForm${system}`).classList.add('hidden');
-  document.getElementById(`results${system}`).classList.add('hidden');
+  const modal = document.getElementById('resultsModal');
+  if (modal) modal.classList.add('hidden');
 
   // Clear manual splice fields
   document.getElementById(`spliceContainer${system}`).innerHTML = '';

--- a/newweeps/index.php
+++ b/newweeps/index.php
@@ -64,7 +64,6 @@
 
     </form>
 
-    <div id="resultsT14000" class="result hidden"></div>
     <button id="downloadT14000" class="hidden">Download Results</button>
   </div>
 
@@ -114,13 +113,17 @@
       <button type="submit">Calculate Points</button>
     </form>
 
-    <div id="resultsT24650" class="result hidden"></div>
     <button id="downloadT24650" class="hidden">Download Results</button>
   </div>
 
-<div id="visual-container" class="hidden">
-  <div id="markpointVisualizer" class="visual-bar"></div>
-</div>
+  <!-- Results Modal -->
+  <div id="resultsModal" class="modal hidden">
+    <div class="modal-content">
+      <span id="closeModal" class="close">&times;</span>
+      <div id="markpointVisualizer" class="visual-bar"></div>
+      <div id="results" class="result"></div>
+    </div>
+  </div>
 
 
   <!-- Theme Toggle Switch -->

--- a/newweeps/main.js
+++ b/newweeps/main.js
@@ -23,4 +23,13 @@ window.addEventListener('DOMContentLoaded', () => {
     if (dl) dl.checked = false;
     if (dr) dr.checked = false;
   });
+
+  const modal = document.getElementById('resultsModal');
+  const close = document.getElementById('closeModal');
+  if (close) close.addEventListener('click', () => modal.classList.add('hidden'));
+  if (modal) {
+    modal.addEventListener('click', e => {
+      if (e.target === modal) modal.classList.add('hidden');
+    });
+  }
 });

--- a/newweeps/styles.css
+++ b/newweeps/styles.css
@@ -133,6 +133,46 @@ button:hover {
   display: none;
 }
 
+/* Modal styles */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.6);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.modal-content {
+  position: relative;
+  background: var(--card-bg);
+  color: var(--text);
+  padding: 20px;
+  border-radius: 8px;
+  max-width: 90%;
+  width: 600px;
+  max-height: 90%;
+  overflow: auto;
+}
+
+.close {
+  position: absolute;
+  top: 10px;
+  right: 15px;
+  font-size: 24px;
+  cursor: pointer;
+}
+
+#markpointVisualizer {
+  width: 100%;
+  height: 150px;
+  margin-bottom: 10px;
+}
+
 /* Tabs */
 .tab-buttons {
   display: flex;

--- a/newweeps/utils.js
+++ b/newweeps/utils.js
@@ -58,7 +58,7 @@ function parseFractionalInput(input) {
     const doc = new jsPDF();
 
     // Add textual results
-    const resDiv = document.getElementById(`results${system}`);
+    const resDiv = document.getElementById('results');
     const text = resDiv ? resDiv.textContent : '';
     const lines = doc.splitTextToSize(text, 180);
     doc.text(lines, 10, 10);

--- a/newweeps/visual.js
+++ b/newweeps/visual.js
@@ -4,106 +4,73 @@
  */
 function visualizeMarkpoints(containerId, spliceSegments, allMarkPoints, totalRunInInches, doorLeft, doorRight) {
   const container = document.getElementById(containerId);
-  if (!container) {
-    console.error("❌ Container not found:", containerId);
-    return;
-  }
+  if (!container) return;
 
-  // Handle missing data
-  const visualContainer = document.getElementById('visual-container');
-  if (!spliceSegments || spliceSegments.length === 0) {
-    if (visualContainer) {
-      visualContainer.classList.add('hidden');
-    }
-    container.innerHTML = '';
-    return;
-  }
-
-  // Unhide visual container
-  if (visualContainer) {
-    visualContainer.classList.remove('hidden');
-  }
-
-  // Reset contents
   container.innerHTML = '';
+  if (!spliceSegments || spliceSegments.length === 0) return;
 
-  // Extensions
   const leftExtension = doorLeft ? 0 : 2.125;
   const rightExtension = doorRight ? 0 : 2.125;
-
   const visualTotalLength = totalRunInInches + leftExtension + rightExtension;
-  const containerWidth = container.offsetWidth;
 
-  // Scale so entire run fits within container (~95%)
-  const scale = (containerWidth * 0.95) / visualTotalLength;
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${visualTotalLength} 40`);
+  svg.setAttribute('width', '100%');
+  svg.setAttribute('height', '40');
+  container.appendChild(svg);
 
-  // 🪵 Debug logging
-  console.group("🔍 Markpoint Visualizer Debug");
-  console.log("📌 containerId:", containerId);
-  console.log("📏 totalRunInInches:", totalRunInInches);
-  console.log("📐 doorLeft:", doorLeft);
-  console.log("📐 doorRight:", doorRight);
-  console.log("➕ leftExtension:", leftExtension);
-  console.log("➕ rightExtension:", rightExtension);
-  console.log("📏 visualTotalLength:", visualTotalLength);
-  console.log("📦 containerWidth (px):", containerWidth);
-  console.log("📊 scale (px per inch):", scale);
-  console.log("📍 Markpoints:", allMarkPoints);
-  console.log("📦 Splice Segments:", spliceSegments);
-  console.groupEnd();
-
-  // Create visual for each splice segment
   spliceSegments.forEach((segment, index) => {
-    const partLetter = String.fromCharCode(65 + index); // A, B, C...
-    const isFirst = index === 0;
-    const isLast = index === spliceSegments.length - 1;
+    let start = segment.start;
+    let end = segment.end;
+    if (index === 0) start -= leftExtension;
+    if (index === spliceSegments.length - 1) end += rightExtension;
 
-    // Segment container
-    const segmentDiv = document.createElement('div');
-    segmentDiv.className = 'segment-container';
+    const rect = document.createElementNS(svgNS, 'rect');
+    rect.setAttribute('x', start);
+    rect.setAttribute('y', 10);
+    rect.setAttribute('width', end - start);
+    rect.setAttribute('height', 6);
+    rect.setAttribute('fill', 'var(--visual-track-bg)');
+    rect.setAttribute('stroke', 'var(--visual-track-border)');
+    svg.appendChild(rect);
 
-    // Segment label (e.g., Part A)
-    const label = document.createElement('div');
-    label.className = 'segment-label';
-    label.textContent = `Part ${partLetter}`;
-    segmentDiv.appendChild(label);
+    const partLabel = document.createElementNS(svgNS, 'text');
+    partLabel.setAttribute('x', (start + end) / 2);
+    partLabel.setAttribute('y', 8);
+    partLabel.setAttribute('text-anchor', 'middle');
+    partLabel.setAttribute('fill', 'var(--text)');
+    partLabel.textContent = `Part ${String.fromCharCode(65 + index)}`;
+    svg.appendChild(partLabel);
 
-    // Track visual bar
-    const track = document.createElement('div');
-    track.className = 'visual-track';
+    const labelBoxes = [];
+    allMarkPoints
+      .filter(pt => pt >= segment.start && pt <= segment.end)
+      .forEach(pt => {
+        const line = document.createElementNS(svgNS, 'line');
+        line.setAttribute('x1', pt);
+        line.setAttribute('x2', pt);
+        line.setAttribute('y1', 10);
+        line.setAttribute('y2', 30);
+        line.setAttribute('stroke', 'var(--markpoint-color)');
+        svg.appendChild(line);
 
-    let segmentStart = segment.start;
-    let segmentEnd = segment.end;
-    if (isFirst) {
-      segmentStart -= leftExtension;
-    }
-    if (isLast) {
-      segmentEnd += rightExtension;
-    }
-    const segmentLengthInches = segmentEnd - segmentStart;
-    track.style.width = `${segmentLengthInches * scale}px`;
-    track.style.position = 'relative';
+        const txt = document.createElementNS(svgNS, 'text');
+        txt.textContent = roundToSixteenths(pt - segment.start);
+        txt.setAttribute('x', pt);
+        txt.setAttribute('text-anchor', 'middle');
+        txt.setAttribute('fill', 'var(--text)');
 
-    // Add markpoints
-    allMarkPoints.forEach((pt) => {
-      if (pt >= segment.start && pt <= segment.end) {
-        const offsetInInches = pt - segmentStart;
-        const posPx = offsetInInches * scale;
-
-        const mark = document.createElement('div');
-        mark.className = 'markpoint';
-        mark.style.left = `${posPx}px`;
-        track.appendChild(mark);
-
-        const lbl = document.createElement('div');
-        lbl.className = 'markpoint-label';
-        lbl.style.left = `${posPx}px`;
-        lbl.textContent = roundToSixteenths(pt - segment.start);
-        track.appendChild(lbl);
-      }
-    });
-
-    segmentDiv.appendChild(track);
-    container.appendChild(segmentDiv);
+        let y = 32;
+        txt.setAttribute('y', y);
+        svg.appendChild(txt);
+        let bbox = txt.getBBox();
+        while (labelBoxes.some(b => !(bbox.x + bbox.width < b.x || b.x + b.width < bbox.x))) {
+          y += 6;
+          txt.setAttribute('y', y);
+          bbox = txt.getBBox();
+        }
+        labelBoxes.push({ x: bbox.x, width: bbox.width });
+      });
   });
 }


### PR DESCRIPTION
## Summary
- Replace per-tab results with a centralized modal containing the markpoint visualizer
- Render markpoints with scalable SVG and basic label collision avoidance
- Update calculation and download logic to populate and export modal contents

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb7d2cc39c832988b931a29bbe495e