### PR TITLE
Add Docker Compose for PHP app

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+services:
+  web:
+    build:
+      context: .
+      dockerfile: dockerfile
+    ports:
+      - "8032:80"
+    volumes:
+      - ./:/var/www/html


### PR DESCRIPTION
## Summary
- add a simple Docker Compose file to build the PHP Apache image and expose port 8032

## Testing
- `docker compose config` *(fails: command not found)*
- `php -l index.php caps.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb84f9aff88329aa5c4ccaa89f5772