### PR TITLE
Fix modal visibility and add reset controls

### DIFF
--- a/newweeps/form.js
+++ b/newweeps/form.js
@@ -115,6 +115,12 @@ function resetForm(system) {
   // Clear form fields and hide sections
   document.getElementById(`bayInputs${system}`).innerHTML = '';
   document.getElementById(`mainForm${system}`).classList.add('hidden');
+
+  ['doorLeft', 'doorRight'].forEach(dir => {
+    const el = document.getElementById(`${dir}${system}`);
+    if (el) el.checked = false;
+  });
+
   const modal = document.getElementById('resultsModal');
   if (modal) modal.classList.add('hidden');
 
@@ -123,7 +129,17 @@ function resetForm(system) {
   document.getElementById(`useManualSplice${system}`).checked = false;
   document.getElementById(`manualSpliceContainer${system}`).classList.add('hidden');
 
-  // Clear visual markout
+  // Clear results and shared visual
+  const visualizer = document.getElementById('markpointVisualizer');
+  if (visualizer) visualizer.innerHTML = '';
+  const resultsDiv = document.getElementById('results');
+  if (resultsDiv) resultsDiv.textContent = '';
+
+  // Hide download button
+  const dlBtn = document.getElementById(`download${system}`);
+  if (dlBtn) dlBtn.classList.add('hidden');
+
+  // Clear any system-specific visual containers
   const visual = document.getElementById(`markoutVisual${system}`);
   if (visual) visual.innerHTML = '';
 }

--- a/newweeps/index.php
+++ b/newweeps/index.php
@@ -111,6 +111,7 @@
       <input type="text" id="spliceGapT24650" value="3/8" />
 
       <button type="submit">Calculate Points</button>
+      <button type="button" onclick="resetForm('T24650')">Start Over</button>
     </form>
 
     <button id="downloadT24650" class="hidden">Download Results</button>

--- a/newweeps/styles.css
+++ b/newweeps/styles.css
@@ -147,6 +147,10 @@ button:hover {
   z-index: 1000;
 }
 
+.modal.hidden {
+  display: none;
+}
+
 .modal-content {
   position: relative;
   background: var(--card-bg);


### PR DESCRIPTION
## Summary
- Ensure modal is hidden on load by adding `.modal.hidden` rule
- Add Start Over button for T24650 and reset logic to clear data, visuals, and download link

## Testing
- `node --check newweeps/form.js`
- `node --check newweeps/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68bb9635f0dc8329889f9d5ba805531c